### PR TITLE
Fix regex and remove optional XPath in identifiers

### DIFF
--- a/input/fsh/invariants/PatientIdentifierConformancePatternSE.fsh
+++ b/input/fsh/invariants/PatientIdentifierConformancePatternSE.fsh
@@ -4,16 +4,14 @@ Description: "All identifiers that identifies as personnummer SHALL comply with 
 ^(18|19|[2-9]\\d)\\d{2}(0[1-9]|1[012])([0-2]\\d|3[0-1])\\d{4}"
 Severity: #error
 // Support dead patients who born in 19th century.
-Expression: "$this.toString().matches('^(18|19|[2-9]\\\\d)\\\\d{2}(0[1-9]|1[012])([0-2]\\\\d|3[0-1])\\\\d{4}')"
-XPath: "f:value"
+Expression: "$this.toString().matches('^(18|19|[2-9]\\d)\\d{2}(0[1-9]|1[012])([0-2]\\d|3[0-1])\\d{4}')"
 
 Invariant: samordningsnummer-invariant
 Description: "All identifiers that identifies as samordningsnummer SHALL comply with the specified regex: 
 ^(18|19|[2-9]\\d)\\d{2}(0[1-9]|1[012])([0-8]\\d|9[0-1])\\d{4}"
 Severity: #error
 // Support dead patients who born in 19th century.
-Expression: "$this.toString().matches('^(18|19|[2-9]\\\\d)\\\\d{2}(0[1-9]|1[012])([0-8]\\\\d|9[0-1])\\\\d{4}')"
-XPath: "f:value"
+Expression: "$this.toString().matches('^(18|19|[2-9]\\d)\\d{2}(0[1-9]|1[012])([0-8]\\d|9[0-1])\\d{4}')"
 
 Invariant: nationelltReservnummer-invariant
 Description: "All identifiers that identifies as nationellt reservnummer SHALL comply with the specified regex:  
@@ -21,7 +19,6 @@ Description: "All identifiers that identifies as nationellt reservnummer SHALL c
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('^([0-9]{8})-?([A-Z&&[^IOQVW]]{2}[0-9]{2}|[A-Z&&[^IOQVW]]{3}[0-9]{1})$')"
-XPath: "f:value"
 
 Invariant: SLL-local-reservnummer-invariant
 Description: "All identifiers that identifies as a SLL local reservnummer SHALL comply with the specified regex: 
@@ -29,7 +26,7 @@ Description: "All identifiers that identifies as a SLL local reservnummer SHALL 
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('99\\d{10}')"
-XPath: "f:value"
+
 
 Invariant: VGR-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Västra Götalandsregionen local reservnummer SHALL comply with the specified regex: 
@@ -37,7 +34,7 @@ Description: "All identifiers that identifies as a Västra Götalandsregionen lo
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('\\d{8}[K|M|X](0[6-9]|[1-8][0-9])[0-9]')"
-XPath: "f:value"
+
 
 Invariant: LiV-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Landstinget i Värmland local reservnummer SHALL comply with the specified regex: 
@@ -45,7 +42,7 @@ Description: "All identifiers that identifies as a Landstinget i Värmland local
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('\\d{8}S[F|U|X|P|L]\\d([A-Z&&[^V]]|[1-9])')"
-XPath: "f:value"
+
 
 Invariant: IneraCareLink-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Inera Carelink local reservnummer SHALL comply with the specified regex: 
@@ -53,7 +50,7 @@ Description: "All identifiers that identifies as a Inera Carelink local reservnu
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('(1[7-9]|20)\\d{2}(0[1-9]|1[0-2])(3[2-9]|[4-5][0-9])\\d{4}')"
-XPath: "f:value"
+
 
 Invariant: Orebro-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Region Örebro län local reservnummer SHALL comply with the specified regex: 
@@ -61,7 +58,7 @@ Description: "All identifiers that identifies as a Region Örebro län local res
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('(1[8-9]|2[0-1])[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])T[A-Z][0-9][A-J]')"
-XPath: "f:value"
+
 
 Invariant: Skane-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Region Skåne local reservnummer SHALL comply with the specified regex: 
@@ -69,7 +66,7 @@ Description: "All identifiers that identifies as a Region Skåne local reservnum
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('^(\\d{6}|\\d{8})[D|E|F][A-Z][0|1][A-Z]$')"
-XPath: "f:value"
+
 
 Invariant: Blekinge-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Region Blekinge local reservnummer SHALL comply with the specified regex: 
@@ -77,7 +74,7 @@ Description: "All identifiers that identifies as a Region Blekinge local reservn
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('^(1[8-9]|2[0-1])[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])[A-Z]{2}[0-9][A-Z]$')"
-XPath: "f:value"
+
 
 Invariant: Vasternorrland-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Region Västernorrland local reservnummer SHALL comply with the specified regex: 
@@ -85,7 +82,7 @@ Description: "All identifiers that identifies as a Region Västernorrland local 
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('^(1[8-9]|2[0-1])[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])[0-9]{3}R$')"
-XPath: "f:value"
+
 
 Invariant: Sormland1-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Region Sörmland 1 local reservnummer SHALL comply with the specified regex: 
@@ -93,7 +90,7 @@ Description: "All identifiers that identifies as a Region Sörmland 1 local rese
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('^(1[8-9]|2[0-1])[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])[A-Z]{2}[0-9][A-Z]$')"
-XPath: "f:value"
+
 
 Invariant: Sormland2-local-reservnummer-invariant
 Description: "All identifiers that identifies as a Region Sörmland 2 local reservnummer SHALL comply with the specified regex: 
@@ -101,4 +98,3 @@ Description: "All identifiers that identifies as a Region Sörmland 2 local rese
 Severity: #error
 // Support dead patients who born in 19th century.
 Expression: "$this.toString().matches('^(18500101|18600101)[MNKP](0{2}[1-9]|[0-9][1-9][0-9]|[1-9][0-9][0-9])$')"
-XPath: "f:value"


### PR DESCRIPTION
The regex for personnummer was escaped a bit too much and didn't work - see this [fhirpath lab link](https://fhirpath-lab.com/FhirPath?expression=identifier.first().value.first().toString().toString().matches(%27%5E(18%7C19%7C%5B2-9%5D%5C%5C%5C%5Cd)%5C%5C%5C%5Cd%7B2%7D(0%5B1-9%5D%7C1%5B012%5D)(%5B0-2%5D%5C%5C%5C%5Cd%7C3%5B0-1%5D)%5C%5C%5C%5Cd%7B4%7D%27)&engine=.NET%20(firely)&resourceJson=FAb2AJwIgJwUwM4HsCuMDGcAqBPADnFOAFzQAKAhgC4CWcAdlVADQTQ0AmRpUAtjfRq8KAGwC0eanUYs2fOFQrdwYSJCh4YSAGY0RhEuADabNdAAWVKngTEA9HfRJevJPU069iAHToK8O21zGhg7AGUqGBR0KjQ4ABE4XUFaNztKWgYqMIBRAGFnV3oEABkaKkJTcABdNgBfVnUKgA8mQ1U1KARFWIRlKABzBjgYajguRs6OGgA3foAeaZnwZt4RYoBeAB0oS2t7OwB3Y+9DgGZvJBgBuwBGAE5Hu2bLNZ2APnm8cG6cfW2oAAjK4cEakW54ZrgADEADZYbcKNptD8kCJOABucCAijoADWAy0KHoHDEThEV1I0LgsJpyKxkg403oA3BAAZIRiPvNAe8ANKifTgPmjeh48DzOy88AACnoSB+PXG4CGJJGAEpmOB4kgAELgACqYvlh3osolTlB7z2eAOcH0MS0gnQ5jgoio5m8CDgdk4WRouhGdgIMGQ9HoKBcI0llrg7zu91uACZk6mU0n1ZK8J9zKFPopAUL0CIKAgEADCZxuZF8xxFX84ACcfjCagSWS0ZSYdoztoAKwcCg7cC0Kj-HZ8k1m7rUFAIcA6cAZaRUD6JTCl8bESVUDi18DkhCSegAs4fbSib07vc7mCfOwF-T3pbvKD1SZQP2MAN0GDKExmB0ZhdDg3RwLw-Q2naDqRG4NAum6Igel6PpfrQgahCGYYRlGf6TMBMyiCgBg8A8abkUmb5mHUbDVB+9AULwJHGFUQGdBe-AiDg-QihQYqyGY6gDLMDD-lUwECiI+hUYJtTUbRH6ghu3ocLqSBom69DKBeIjesAdRAA&terminologyserver=https%3A%2F%2Fsqlonfhir-r4.azurewebsites.net%2Ffhir) for a demo.

Here's a demo of the [fixed version](https://fhirpath-lab.com/FhirPath?expression=identifier.first().value.first().toString().toString().matches(%27%5E(18%7C19%7C%5B2-9%5D%5C%5Cd)%5C%5Cd%7B2%7D(0%5B1-9%5D%7C1%5B012%5D)(%5B0-2%5D%5C%5Cd%7C3%5B0-1%5D)%5C%5Cd%7B4%7D%27)&engine=fhirpath.js&resourceJson=FAb2AJwIgJwUwM4HsCuMDGcAqBPADnFOAFzQAKAhgC4CWcAdlVADQTQ0AmRpUAtjfRq8KAGwC0eanUYs2fOFQrdwYSJCh4YSAGY0RhEuADabNdAAWVKngTEA9HfRJevJPU069iAHToK8O21zGhg7AGUqGBR0KjQ4ABE4XUFaNztKWgYqMIBRAGFnV3oEABkaKkJTcABdNgBfVnUKgA8mQ1U1KARFWIRlKABzBjgYajguRs6OGgA3foAeaZnwZt4RYoBeAB0oS2t7OwB3Y+9DgGZvJBgBuwBGAE5Hu2bLNZ2APnm8cG6cfW2oAAjK4cEakW54ZrgADEADZYbcKNptD8kCJOABucCAijoADWAy0KHoHDEThEV1I0LgsJpyKxkg403oA3BAAZIRiPvNAe8ANKifTgPmjeh48DzOy88AACnoSB+PXG4CGJJGAEpmOB4kgAELgACqYvlh3osolTlB7z2eAOcH0MS0gnQ5jgoio5m8CDgdk4WRouhGdgIMGQ9HoKBcI0llrg7zu91uACZk6mU0n1ZK8J9zKFPopAUL0CIKAgEADCZxuZF8xxFX84ACcfjCagSWS0ZSYdoztoAKwcCg7cC0Kj-HZ8k1m7rUFAIcA6cAZaRUD6JTCl8bESVUDi18DkhCSegAs4fbSib07vc7mCfOwF-T3pbvKD1SZQP2MAN0GDKExmB0ZhdDg3RwLw-Q2naDqRG4NAum6Igel6PpfrQgahCGYYRlGf6TMBMyiCgBg8A8abkUmb5mHUbDVB+9AULwJHGFUQGdBe-AiDg-QihQYqyGY6gDLMDD-lUwECiI+hUYJtTUbRH6ghu3ocLqSBom69DKBeIjesAdRAA&terminologyserver=https%3A%2F%2Fsqlonfhir-r4.azurewebsites.net%2Ffhir) where it does work.

Also removed the XPath - it is [optional per spec](https://hl7.org/fhir/uv/shorthand/reference.html#defining-invariants) and the ones we have weren't actually validating.