### PR TITLE
Add IG build validation

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,0 +1,42 @@
+name: Validate docs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
+
+jobs:
+  sushi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Validate with Sushi
+        run: sushi .
+
+  ig-publisher:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Jekyll
+        run: sudo gem install jekyll
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Install IG publisher
+        run: |
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+
+      - name: Validate IG
+        run: |
+          chmod +x ./_genonce.sh
+          ./_genonce.sh

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -2,7 +2,7 @@ name: Validate docs
 
 on:
   push:
-    branches: '*'
+    branches: '**'
   pull_request:
     types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
 
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Sushi
         run: sudo npm install -g fsh-sushi
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Jekyll
         run: sudo gem install jekyll

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -5,6 +5,7 @@ on:
     branches: '**'
   pull_request:
     types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
+  workflow_dispatch:
 
 jobs:
   sushi:

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -2,7 +2,7 @@ name: Validate docs
 
 on:
   push:
-    branches: [ master ]
+    branches: '*'
   pull_request:
     types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
 


### PR DESCRIPTION
Added validation to PRs and any commits to the `master` branch to ensure that only content that builds an IG successfully makes it in. This will help ensure that we don't get any broken builds.

Any QA errors or warnings will still be allowed though.

Example of this workflow running can be found down below 👇