### PR TITLE
Enable pinning of canonical URL references

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -30,6 +30,7 @@ fhirVersion: 4.0.1
 parameters:
   show-inherited-invariants: false
   path-expansion-params: Parameters-exp-params.json
+  pin-canonicals: pin-all
 copyrightYear: 2020+
 releaseLabel: release
 


### PR DESCRIPTION
Enable pinning of canonical URL references, a best practice as suggested by Grahame Grieve at the post-Vitalis workshop in this May. See [pin-canonicals](https://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html) documentation.