### PR TITLE
Add FCP308/309 sections, refresh contact info

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -13,14 +13,22 @@ The development of this implementation guide is carried out by a work group unde
 Framtagandet av dessa basprofiler och utökningar genomförs av en arbetsgrupp under HL7 Sverige <http://hl7.se>. Gruppen består av representanter från regioner, myndigheter, systemleverantörer samt andra experter inom FHIR, informatik, arkitektur, terminologi etc.
 -->
 
-### Contact information
-To reach the working group for the Swedish base profiles: 
-[Arvid Thunholm](mailto:arvid.thunholm@gmail.com) - Chairman HL7 WG base profiles
+### Getting involved
+Work on this implementation guide is coordinated through HL7 Sweden's open meetings and working groups. The base profiles working group meets regularly, and the monthly Samordningsmöte (coordination meeting) is open to anyone interested in Swedish FHIR work.
 
-<!---
-För att komma i kontakt med gruppen som arbetar med FHIR basprofiler:
-[Arvid Thunholm](mailto:arvid.thunholm@gmail.com) - Ordförande HL7 basprofiler
--->
+For meeting cadence, joining instructions, and other communication channels, see the HL7 Sweden [Meetings page](https://confluence.hl7.org/spaces/HS/pages/248875365/Meetings). General enquiries can be sent to <info@hl7.se>.
+
+### Raising issues
+Issues, errata, and change requests against this implementation guide are tracked on GitHub at <https://github.com/HL7Sweden/basprofiler-r4/issues>. To raise an issue, open a new issue in that tracker; please include the affected resource, the IG version, and a clear description of the problem or proposal.
+
+For general questions or discussion that are not issues against the specification, see [Getting involved](#getting-involved) above.
+
+### Security, safety, and privacy
+This implementation guide defines structural profiles, extensions, value sets, and code systems only. It does not specify exchange protocols, authentication, authorisation, or audit mechanisms, and it does not itself process or transmit personal data. Implementers remain responsible for applying appropriate security, safety, and privacy controls in their own systems, including (but not limited to) compliance with the EU General Data Protection Regulation (GDPR), the Swedish Patient Data Act, Patientdatalag (2008:355), and any sector-specific requirements that apply to their deployment.
+
+The Swedish personal identity number (`personnummer`) and other identifiers profiled in this guide are sensitive personal data under Swedish law. Implementations using these profiles must ensure that storage, transmission, access control, and audit logging meet the applicable legal and organisational requirements.
+
+No security, safety, or privacy issues specific to the artefacts in this implementation guide are currently known. To report a suspected security, safety, or privacy issue, open an issue at <https://github.com/HL7Sweden/basprofiler-r4/issues>; if the issue is sensitive and should not be disclosed publicly, contact HL7 Sweden directly at <info@hl7.se> instead.
 
 ### IP Statements
 


### PR DESCRIPTION
Adds Raising issues (FCP308) and Security/safety/privacy (FCP309) sections to index.md, and replaces the stale Contact information block with a Getting involved section pointing to the HL7 Sweden Meetings page.

Additionally, fixed canonical URLs - e.g. http://hl7.se/fhir/ig/base/ValueSet/SEBaseHSAVerksamhetVS - to redirect to latest 1.1.0 release instead of the outdated 1.0.0 and use https URLs. This was a server-side fix outside this PR.